### PR TITLE
Separate only-auth and admin classes

### DIFF
--- a/fastapi_keycloak/__init__.py
+++ b/fastapi_keycloak/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = "1.1.0-rc"
 
-from fastapi_keycloak.api import FastAPIKeycloak
+from fastapi_keycloak.api import FastAPIKeycloak, FastAPIKeycloakAuth
 from fastapi_keycloak.model import (
     HTTPMethod,
     KeycloakError,
@@ -17,6 +17,7 @@ from fastapi_keycloak.model import (
 
 __all__ = [
     FastAPIKeycloak.__name__,
+    FastAPIKeycloakAuth.__name__,
     OIDCUser.__name__,
     UsernamePassword.__name__,
     HTTPMethod.__name__,


### PR DESCRIPTION
By default `FastAPIKeycloak` class requests admin token and contains a lot of admin-related operations.

This makes it had to use the library for authentication (token validation) only, as admin secret is not always available, and admin functions are not always needed.

In this PR I add `FastAPIKeycloakAuth` class which handles only token validation. Old `FastAPIKeycloak` inherits this new class and contains all features available previously, enabling seamless migration for old users.